### PR TITLE
Run battles asyncronously

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -38,6 +38,7 @@ pylint:
     - import-error
     - relative-beyond-top-level
     - arguments-differ
+    - invalid-name
   options:
     max-line-length: 100
 

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,6 @@ compile_install_requirements:
 	pip-compile dev-requirements.in > dev-requirements.txt
 	@echo 'Installing requirements...'
 	pip install -r requirements.txt && pip install -r dev-requirements.txt
+
+celery_run:
+	celery worker --workdir backend --app=pokebattle --loglevel=info

--- a/backend/battles/admin.py
+++ b/backend/battles/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from battles.utils.battle import run_battle_and_send_result_email
+from battles.tasks import run_battle_and_send_result_email
 
 from .models import Battle, BattleTeam
 
@@ -12,7 +12,7 @@ class BattleAdmin(admin.ModelAdmin):
 class BattleTeamAdmin(admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
-        run_battle_and_send_result_email(obj)
+        run_battle_and_send_result_email.delay(obj.battle.id)
 
 
 admin.site.register(Battle, BattleAdmin)

--- a/backend/battles/admin.py
+++ b/backend/battles/admin.py
@@ -12,7 +12,7 @@ class BattleAdmin(admin.ModelAdmin):
 class BattleTeamAdmin(admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
-        run_battle_and_send_result_email.delay(obj.battle.id)
+        run_battle_and_send_result_email.delay(obj.battle_id)
 
 
 admin.site.register(Battle, BattleAdmin)

--- a/backend/battles/forms.py
+++ b/backend/battles/forms.py
@@ -28,6 +28,7 @@ class AutocompletePokemonForm(forms.ModelForm):
             attrs={  # noqa
                 "data-placeholder": "Autocomplete pokemon",
                 "data-minimum-input-length": 3,
+                "data-html": True,
             },
         ),
         required=True,
@@ -40,6 +41,7 @@ class AutocompletePokemonForm(forms.ModelForm):
             attrs={  # noqa
                 "data-placeholder": "Autocomplete pokemon",
                 "data-minimum-input-length": 3,
+                "data-html": True,
             },
         ),
         required=True,
@@ -52,6 +54,7 @@ class AutocompletePokemonForm(forms.ModelForm):
             attrs={  # noqa
                 "data-placeholder": "Autocomplete pokemon",
                 "data-minimum-input-length": 3,
+                "data-html": True,
             },
         ),
         required=True,

--- a/backend/battles/tasks.py
+++ b/backend/battles/tasks.py
@@ -1,0 +1,21 @@
+from celery.utils.log import get_task_logger
+
+from pokebattle import celery_app
+
+from .models import Battle
+from .utils.battle import get_battle_winner
+from .utils.email import send_battle_result
+
+
+logger = get_task_logger(__name__)
+
+
+@celery_app.task
+def run_battle_and_send_result_email(battle_id):
+    logger.info("About to solve Battle %d", battle_id)
+    battle = Battle.objects.get(id=battle_id)
+    battle.winner = get_battle_winner(battle)
+    battle.status = "SETTLED"
+    battle.save()
+    logger.info("Solved Battle %d", battle_id)
+    send_battle_result(battle)

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -257,7 +257,7 @@ class SelectOpponentTeamViewTest(MakePokemonMixin, CreatorAndOpponentMixin, Test
     def test_if_battle_values_change(self):
         # test if the battle values change (its status and winner)
         # after running run_battle_and_send_result_email
-        self.creator_pokemon_team = mommy.make(  # noqa
+        creator_pokemon_team = mommy.make(  # noqa
             "battles.BattleTeam",
             creator=self.creator,
             battle=self.matching_battle,

--- a/backend/battles/utils/battle.py
+++ b/backend/battles/utils/battle.py
@@ -1,6 +1,3 @@
-from .email import send_battle_result
-
-
 def compare_pokemon_attack_and_defense(pokemon_1, pokemon_2):
     # pokemon_1 always attacks and pokemon_2 always defends
     if pokemon_1.attack > pokemon_2.defense:
@@ -50,11 +47,3 @@ def get_battle_winner(battle):
     if creator_wins > opponent_wins:
         return battle.creator
     return battle.opponent
-
-
-def run_battle_and_send_result_email(battle_team):
-    battle = battle_team.battle
-    battle.winner = get_battle_winner(battle)
-    battle.status = "SETTLED"
-    battle.save()
-    send_battle_result(battle)

--- a/backend/battles/views.py
+++ b/backend/battles/views.py
@@ -10,7 +10,8 @@ from pokemon.helpers import sort_pokemon_in_correct_position
 
 from .forms import CreateBattleForm, SelectOpponentTeamForm
 from .models import Battle, BattleTeam
-from .utils.battle import get_round_winner, run_battle_and_send_result_email
+from .tasks import run_battle_and_send_result_email
+from .utils.battle import get_round_winner
 from .utils.email import send_opponent_battle_invitation_email
 
 
@@ -84,8 +85,7 @@ class SelectOpponentTeamView(LoginRequiredMixin, generic.CreateView):
         form.instance.pokemon_3 = pokemon["pokemon_3"]
 
         form.instance.save()
-
-        run_battle_and_send_result_email(form.instance)
+        run_battle_and_send_result_email.delay(form.instance.battle.id)
 
         return super().form_valid(form)
 

--- a/backend/pokebattle/settings/local_base.py
+++ b/backend/pokebattle/settings/local_base.py
@@ -19,7 +19,7 @@ STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
 AUTH_PASSWORD_VALIDATORS = []  # allow easy passwords only on local
 
 # Celery
-# CELERY_TASK_ALWAYS_EAGER = True
+CELERY_TASK_ALWAYS_EAGER = False
 
 # Email
 INSTALLED_APPS += ("naomi",)

--- a/backend/pokebattle/settings/local_base.py
+++ b/backend/pokebattle/settings/local_base.py
@@ -19,7 +19,7 @@ STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
 AUTH_PASSWORD_VALIDATORS = []  # allow easy passwords only on local
 
 # Celery
-CELERY_TASK_ALWAYS_EAGER = True
+# CELERY_TASK_ALWAYS_EAGER = True
 
 # Email
 INSTALLED_APPS += ("naomi",)

--- a/backend/pokemon/constants.py
+++ b/backend/pokemon/constants.py
@@ -1,0 +1,1 @@
+POKE_API_URL = "https://pokeapi.co/api/v2/pokemon/"

--- a/backend/pokemon/helpers.py
+++ b/backend/pokemon/helpers.py
@@ -1,10 +1,8 @@
 import requests
 from progress.bar import ChargingBar
 
+from .constants import POKE_API_URL
 from .models import Pokemon
-
-
-POKE_API_URL = "https://pokeapi.co/api/v2/pokemon/"
 
 
 def get_all_pokemon_from_api():

--- a/backend/pokemon/helpers.py
+++ b/backend/pokemon/helpers.py
@@ -1,3 +1,5 @@
+from urllib.parse import urljoin
+
 import requests
 from progress.bar import ChargingBar
 
@@ -6,7 +8,8 @@ from .models import Pokemon
 
 
 def get_all_pokemon_from_api():
-    response = requests.get(f"{POKE_API_URL}?limit=802")
+    url = urljoin(POKE_API_URL, "?limit=802")
+    response = requests.get(url)
     data = response.json()
 
     progress_bar = ChargingBar("Processing", max=802)
@@ -17,7 +20,8 @@ def get_all_pokemon_from_api():
 
 
 def get_pokemon_from_api(poke_name):
-    response = requests.get(f"{POKE_API_URL}{poke_name}")
+    url = urljoin(POKE_API_URL, poke_name)
+    response = requests.get(url)
     data = response.json()
     return {
         "poke_id": data["id"],
@@ -30,7 +34,8 @@ def get_pokemon_from_api(poke_name):
 
 
 def pokemon_exists_in_api(poke_name):
-    response = requests.head(f"{POKE_API_URL}{poke_name}")
+    url = urljoin(POKE_API_URL, poke_name)
+    response = requests.head(url)
     return bool(response)
 
 

--- a/backend/pokemon/tests/test_helpers.py
+++ b/backend/pokemon/tests/test_helpers.py
@@ -1,7 +1,8 @@
 import requests_mock
 
 from common.utils.tests import TestCaseUtils
-from pokemon.helpers import POKE_API_URL, get_all_pokemon_from_api
+from pokemon.constants import POKE_API_URL
+from pokemon.helpers import get_all_pokemon_from_api
 from pokemon.models import Pokemon
 
 

--- a/backend/pokemon/views.py
+++ b/backend/pokemon/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.utils.html import format_html
 
 from dal import autocomplete
 
@@ -13,3 +14,6 @@ class PokemonAutocompleteView(LoginRequiredMixin, autocomplete.Select2QuerySetVi
             qs = qs.filter(name__istartswith=self.q)
 
         return qs
+
+    def get_result_label(self, result):
+        return format_html('<img src="{}" height="60px"> {}', result.img_url, result.name)

--- a/backend/pokemon/views.py
+++ b/backend/pokemon/views.py
@@ -17,3 +17,6 @@ class PokemonAutocompleteView(LoginRequiredMixin, autocomplete.Select2QuerySetVi
 
     def get_result_label(self, result):
         return format_html('<img src="{}" height="60px"> {}', result.img_url, result.name)
+
+    def get_selected_result_label(self, result):
+        return result.name

--- a/backend/templates/auth/login.html
+++ b/backend/templates/auth/login.html
@@ -18,7 +18,7 @@
         <div class="battle-form-field">
           <div>{{ field.label }}: </div>
           {% render_field field %}
-          {{ field.errors }}
+          <span class="field-error">{{ field.errors }}</span>
         </div>
       {% endfor %}
       <div class="btn-container">

--- a/backend/templates/auth/signup.html
+++ b/backend/templates/auth/signup.html
@@ -23,7 +23,7 @@
         <div class="battle-form-field">
           <div>{{ field.label }}: </div>
           {% render_field field %}
-          {{ field.errors }}
+          <span class="field-error">{{ field.errors }}</span>
         </div>
       {% endfor %}
       <div class="btn-container">

--- a/backend/templates/create_battle.html
+++ b/backend/templates/create_battle.html
@@ -9,7 +9,7 @@
   {% include "includes/title.html" with title="Create Battle" %}
   {% if form.errors %}
     {% for error in form.non_field_errors %}
-      <p class="error">{{error}}</p>
+      <div class="error">{{error}}</div>
     {% endfor %}
   {% endif %}
   <div class='content'>

--- a/backend/templates/create_battle.html
+++ b/backend/templates/create_battle.html
@@ -25,7 +25,7 @@
         <div class="battle-form-field">
           <span>{{ field.label }}: </span>
           {% render_field field %}
-          {{ field.errors }}
+          <span class="field-error">{{ field.errors }}</span>
         </div>
       {% endfor %}
       <div class="btn-container">

--- a/backend/templates/select_opponent_team.html
+++ b/backend/templates/select_opponent_team.html
@@ -24,7 +24,7 @@
         <div class="battle-form-field">
           <span>{{ field.label }}: </span>
           {% render_field field %}
-          {{ field.errors }}
+          <span class="field-error">{{ field.errors }}</span>
         </div>
       {% endfor %}
       <div class="btn-container">

--- a/backend/templates/select_opponent_team.html
+++ b/backend/templates/select_opponent_team.html
@@ -9,7 +9,7 @@
   {% include "includes/title.html" with title=page_title %}
   {% if form.errors %}
     {% for error in form.non_field_errors %}
-      <p class="error">{{error}}</p>
+      <div class="error">{{error}}</div>
     {% endfor %}
   {% endif %}
   <div class='content'>

--- a/backend/users/forms.py
+++ b/backend/users/forms.py
@@ -1,5 +1,4 @@
-# from django import forms
-from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
 
 from users.models import User
 
@@ -8,3 +7,7 @@ class SignUpForm(UserCreationForm):
     class Meta:
         model = User
         fields = ["email"]
+
+
+class LoginForm(AuthenticationForm):
+    error_messages = {"invalid_login": ("Please enter a correct %(username)s and password.")}

--- a/backend/users/tasks.py
+++ b/backend/users/tasks.py
@@ -1,6 +1,6 @@
 from django.core import management
 
-from backend.pokebattle import celery_app
+from pokebattle import celery_app
 
 
 @celery_app.task

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -5,7 +5,7 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse_lazy
 from django.views import generic
 
-from .forms import SignUpForm
+from .forms import LoginForm, SignUpForm
 
 
 class SignUpView(generic.CreateView):
@@ -31,6 +31,7 @@ class SignUpView(generic.CreateView):
 
 class UserLoginView(LoginView):
     redirect_authenticated_user = True
+    authentication_form = LoginForm
     template_name = "auth/login.html"
 
 

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -7,9 +7,9 @@ from django.urls import reverse_lazy
 from django.utils.html import format_html
 from django.views import generic
 
-from .forms import InviteUserForm, SignUpForm, LoginForm
-
 from battles.utils.email import send_user_invite_to_pokebattle
+
+from .forms import InviteUserForm, LoginForm, SignUpForm
 
 
 class SignUpView(generic.CreateView):

--- a/frontend/sass/components/_common.scss
+++ b/frontend/sass/components/_common.scss
@@ -179,6 +179,21 @@ footer {
     font-weight: 600;
 }
 
+.field-error {
+    padding: 5px 0;
+    font-size: 14px;
+    font-weight: 600;
+
+    ul {
+        margin: 0;
+        padding: 0;
+    }
+
+    li {
+        list-style: none;
+    }
+}
+
 /* Lists syle */
 
 .battle-list {

--- a/frontend/sass/components/_common.scss
+++ b/frontend/sass/components/_common.scss
@@ -167,9 +167,15 @@ footer {
 
 /* Forms errors */
 .error {
-    color: $pk-light-red;
+    background-color: $pk-light-yellow;
+    color: #fff;
+    width: fit-content;
+    margin: auto;
+    padding: 25px;
+    box-shadow: 3px 3px 5px 0px #cccccc;
+    border-radius: 5px;
     text-align: center;
-    margin: 0!important;
+    font-weight: 600;
 }
 
 /* Lists syle */

--- a/frontend/sass/components/_common.scss
+++ b/frontend/sass/components/_common.scss
@@ -171,6 +171,7 @@ footer {
     color: #fff;
     width: fit-content;
     margin: auto;
+    margin-top: 20px;
     padding: 25px;
     box-shadow: 3px 3px 5px 0px #cccccc;
     border-radius: 5px;

--- a/frontend/sass/settings/_variables.scss
+++ b/frontend/sass/settings/_variables.scss
@@ -5,7 +5,7 @@ $pb-font-family-sans-serif: 'Montserrat Alternates';
 // Pokemon Pallet Color
 $pk-light-red: #FF0000;
 $pk-dark-red: #CC0000;
-$pk-light-yellow: #FFDE00;
+$pk-light-yellow: #e0c302;
 $pk-dark-yellow: #B3A125;
 $pk-blue: #3B4CCA;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2466,9 +2466,9 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cacache": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-      "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+      "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
       "requires": {
         "bluebird": "^3.5.5",
         "chownr": "^1.1.1",
@@ -4436,9 +4436,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
           "dev": true
         }
       }
@@ -4884,9 +4884,9 @@
       }
     },
     "figgy-pudding": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+      "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
     },
     "figures": {
       "version": "3.2.0",
@@ -5163,8 +5163,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5182,13 +5181,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5201,18 +5198,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5315,8 +5309,7 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5326,7 +5319,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5339,20 +5331,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5369,7 +5358,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5450,8 +5438,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5461,7 +5448,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5537,8 +5523,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5568,7 +5553,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5586,7 +5570,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5625,13 +5608,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -5897,15 +5878,16 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
-      "integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
       "dev": true,
       "requires": {
+        "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "source-map": {
@@ -8852,9 +8834,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mississippi": {
       "version": "3.0.0",
@@ -8893,18 +8875,11 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
+        "minimist": "^1.2.5"
       }
     },
     "moo": {
@@ -9482,24 +9457,6 @@
       "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
       "requires": {
         "is-wsl": "^1.1.0"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        }
       }
     },
     "optionator": {
@@ -12297,9 +12254,9 @@
       "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
     },
     "uglify-js": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
-      "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.1.tgz",
+      "integrity": "sha512-W7KxyzeaQmZvUFbGj4+YFshhVrMBGSg2IbcYAjGWGvx8DHvJMclbTDMpffdxFUGPBHjIytk7KJUR/KUXstUGDw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -13198,9 +13155,9 @@
       "dev": true
     },
     "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "worker-farm": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description
<!-- Describe your changes in detail -->
- Create a Celery task to run the battles asuncronously;
- Improve form errors messages and field errors style;
- Override the LoginForm's _invalid login_ error (it was "Please enter a correct username and password. Note that both fields may be case-sensitive." now it's just "Please enter a correct username and password." to keep it simpler);
- Show Pokemon icon and name on the Autocomplete field.
## Related card
<!-- What is the link to the Trello card? -->
[As the programmer I run battles asyncronously](https://trello.com/c/NUCCS6oe/14-as-the-programmer-i-run-battles-asyncronously)
## Screenshots (if appropriate)
The frontend adjusts:
![image](https://user-images.githubusercontent.com/24635967/78578042-538adb00-7805-11ea-97d2-cea58174e026.png)
![image](https://user-images.githubusercontent.com/24635967/78578058-58e82580-7805-11ea-963c-14026f63d5e3.png)
## Steps to reproduce
- Run the project (`python backend/manage.py runserver` and `npm run start`);
- Run `make celery_run`;
- Create a battle;
- Fight back as the opponent (on the terminal running Celery, it will display a message before and after solving the battle).

## Tests
### Overview
- [X] I assure that I've tested the functionality as a real user
- [X] I assure that I've tested success and error cases
- [X] I assure that I've tested other parts of the system that may be impacted by my changes
- [ ] I've written unit tests for this code
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Another type of change, e.g. documentation
## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I've updated the documentation accordingly
- [ ] My change requires a change to the dependencies and I've updated the dependencies accordingly
